### PR TITLE
symetry operation applied on the symetric exchange

### DIFF
--- a/src/Energy/Exchange_Heisenberg_general.f90
+++ b/src/Energy/Exchange_Heisenberg_general.f90
@@ -137,32 +137,6 @@ subroutine get_exchange_ExchG(Ham,io,lat,Ham_shell_pos,neighbor_pos_list)
 
                     symop=my_symmetries%rotmat(k)%mat
                     name_sym=my_symmetries%rotmat(k)%name
-
-!                    if (k.gt.my_symmetries%n_sym) then
-!                       write(output_unit,'(/a)') 'WARNING: symmetry not found - I use an arbitrary rotation'
-!                       axis=rotation_axis(bound_input,vec_tmp)
-!                       if (norm(axis).lt.1.0d-8) axis=(/0.0d0,0.0d0,1.0d0/)
-!                       scalaire=dot_product(bound_input,vec_tmp)
-!                       if (scalaire.ge.1.0d0) then
-!                          angle=0.0d0
-!                       elseif (scalaire.le.-1.0d0) then
-!                          angle=pi
-!                       else
-!                          angle=acos(scalaire)
-!                       endif
-!                       call check_rotate_matrix(angle,axis,bound_input,vec_tmp)
-!                       call rotation_matrix_real(symop,angle,axis)
-!                       name_sym="rotation matrix"
-!                       write(output_unit,'(a,f8.3)') 'angle ', angle*180.0/pi
-!                       write(output_unit,'(a,3f8.3/)') 'axis ', axis
-!
-!                    else
-!
-!                       symop=my_symmetries%rotmat(k)%mat
-!                       name_sym=my_symmetries%rotmat(k)%name
-!
-!                    endif
-
                     call rotate_exchange(J,J_init,symop)
 
                     !endif

--- a/src/matrix_utils/determinant.f90
+++ b/src/matrix_utils/determinant.f90
@@ -1,4 +1,8 @@
 module m_determinant
+implicit none
+
+private
+public :: determinant
 
 interface determinant
   module procedure :: det_real,det_complex
@@ -7,9 +11,6 @@ end interface determinant
 interface TSGT
   module procedure :: TSRGT,TSCGT
 end interface TSGT
-
-private
-public :: determinant
 
 contains
 

--- a/src/symmetries/sym_utils.f90
+++ b/src/symmetries/sym_utils.f90
@@ -1,5 +1,6 @@
 module m_sym_utils
 use m_rotation_matrix, only : rotate_matrix,check_rotate_matrix,rotation_matrix_real
+use m_determinant, only : determinant
 implicit none
 
 private
@@ -16,18 +17,18 @@ subroutine rotate_exchange(mat_out,mat_in,rotmat)
    real(8), intent(in)    :: mat_in(:,:)
    real(8), intent(in)    :: rotmat(:,:)
 
-   real(8)                :: mat(3,3),sym_part(3,3),antisym_part(3,3)
+   real(8)                :: mat_asym(3,3),mat_sym(3,3),sym_part(3,3),antisym_part(3,3)
 
 ! decompose in symmetric and antisymmetric part
 
    sym_part=(mat_in+transpose(mat_in))/2.0d0
    antisym_part=(mat_in-transpose(mat_in))/2.0d0
 
-! rotate only the antisymmetric part
+   call rotate_matrix(mat_sym,sym_part,rotmat)
+! rotate only the antisymmetric part. This part is DMI related so it is an axial vector symmetry which has to be multiplied by det(sym_mat)
+   call rotate_matrix(mat_asym,antisym_part,rotmat)
 
-   call rotate_matrix(mat,antisym_part,rotmat)
-
-   mat_out=sym_part+mat
+   mat_out=mat_sym+mat_asym*determinant(1.0d-8,3,rotmat)
 
 end subroutine
 


### PR DESCRIPTION
The symmetry operations are applied on the symetric part of the exchange
the DMI symmetry operations must be multiplied by the det of the operation to take into account the change of symmetry coming from possible mirror planes and inversion centers on axial vectors